### PR TITLE
Use $persistentDir in the symlinks instead of a hard coded value

### DIFF
--- a/resources/deploy/Envoy.blade.php
+++ b/resources/deploy/Envoy.blade.php
@@ -149,12 +149,12 @@ DEPLOY_REPOSITORY=
     # Remove the storage directory and replace with persistent data
     rm -rf {{ $newReleaseDir }}/storage;
     cd {{ $newReleaseDir }};
-    ln -nfs {{ $baseDir }}/persistent/storage storage;
+    ln -nfs {{ $persistentDir }}/storage storage;
 
     # Remove the public/media directory and replace with persistent data
     rm -rf {{ $newReleaseDir }}/public/media;
     cd {{ $newReleaseDir }};
-    ln -nfs {{ $baseDir }}/persistent/media public/media;
+    ln -nfs {{ $persistentDir }}/media public/media;
 
     # Import the environment config
     cd {{ $newReleaseDir }};


### PR DESCRIPTION
Hi,

First, thanks for this package ! Haven't had the opportunity to test it yet, but it'll arrive soon enough.

---

So, here's a small PR to "improve" it.

You are using the `{{ $baseDir }}/persistent` for the symlinks instead of using the `$persistentDir`. Thus customisation of that folder was not possible.