### PR TITLE
fix checks for customizable env variable

### DIFF
--- a/resources/deploy/Envoy.blade.php
+++ b/resources/deploy/Envoy.blade.php
@@ -39,11 +39,11 @@ DEPLOY_REPOSITORY=
     }
 
     # Config variables
-    $configReleasesDir    = strlen(getenv('DEPLOY_DIR_RELEASES') > 0) ? getenv('DEPLOY_DIR_RELEASES') : "releases";
-    $configPersistentDir  = strlen(getenv('DEPLOY_DIR_PERSISTENT') > 0) ? getenv('DEPLOY_DIR_PERSISTENT') : "persistent";
-    $currentName          = strlen(getenv('DEPLOY_CURRENT') > 0) ? getenv('DEPLOY_CURRENT') : "current";
-    $deploySshPort        = strlen(getenv('DEPLOY_SSH_PORT') > 0) ? getenv('DEPLOY_SSH_PORT') : "22";
-    $branch               = strlen(getenv('DEPLOY_BRANCH') > 0) ? getenv('DEPLOY_BRANCH') : "master";
+    $configReleasesDir    = strlen(getenv('DEPLOY_DIR_RELEASES')) > 0 ? getenv('DEPLOY_DIR_RELEASES') : "releases";
+    $configPersistentDir  = strlen(getenv('DEPLOY_DIR_PERSISTENT')) > 0 ? getenv('DEPLOY_DIR_PERSISTENT') : "persistent";
+    $currentName          = strlen(getenv('DEPLOY_CURRENT')) > 0 ? getenv('DEPLOY_CURRENT') : "current";
+    $deploySshPort        = strlen(getenv('DEPLOY_SSH_PORT')) > 0 ? getenv('DEPLOY_SSH_PORT') : "22";
+    $branch               = strlen(getenv('DEPLOY_BRANCH')) > 0 ? getenv('DEPLOY_BRANCH') : "master";
 
     # Paths
     $releasesDir    = "{$baseDir}/{$configReleasesDir}";


### PR DESCRIPTION
Hi,

Found an other small issue.

The closing parentheses of the checks for the optional env variable was misplace, which lead to the check being always false.

Thus, it was impossible to customise the different directories, branch or ssh port.