### PR TITLE
fix directory and numbers of old releases that are cleaned

### DIFF
--- a/resources/deploy/Envoy.blade.php
+++ b/resources/deploy/Envoy.blade.php
@@ -197,7 +197,7 @@ DEPLOY_REPOSITORY=
     {{ logMessage("🚾  Cleaning up old releases...") }}
     # Delete all but the 3 most recent.
     cd {{ $releasesDir }}
-    ls -dt {{ $releasesDir }}/* | tail -n +3 | xargs -d "\n" rm -rf;
+    ls -dt ./* | tail -n +4 | xargs -d "\n" rm -rf;
 @endtask
 
 @task('finishDeploy', ['on' => 'local'])


### PR DESCRIPTION
Hi,

the `ls -dt` was reading into the wrong directory. On the line just before it, you are `cd {{ $releasesDir }}`, thus trying to `ls {{ $releasesDir }}/*` was never returning any results.

Two solutions here:
- either simply `cd` to return to the `~` of the user, then we can list the content of `{{ $releasesDir }}/*`.
- either we list the content of `./*` because we are already into `{{ $releasesDir }}`.


Also, it seems that `tail -n +3` actually start from the third line, but also include that line into the results. Thus, we only had 2 of the most recent releases left.

I tested on our dev server that is running Debian 9, so the `tail` issue might actually work properly on a CentOS.