### PR TITLE
fix the hipchat directive issue

### DIFF
--- a/resources/deploy/Envoy.blade.php
+++ b/resources/deploy/Envoy.blade.php
@@ -232,12 +232,6 @@ DEPLOY_REPOSITORY=
     }
 
     if ($hipChatWebHook && $hipChatRoom && $hipChatFrom) {
-        @hipchat(
-            $hipChatWebHook,
-            $hipChatRoom,
-            $hipChatFrom,
-            $hipChatCustomMessage,
-            $hipChatColor
-        )
+        @hipchat($hipChatWebHook, $hipChatRoom, $hipChatFrom, $hipChatCustomMessage, $hipChatColor)
     }
 @endfinished


### PR DESCRIPTION
It fix the issue I introduce in #6.

The problem was with the regex parsing for the directives. It doesn't support multiline parameters.