### PR TITLE
Add Laravel 5.6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "laravel/envoy": "~1.3.4",
+        "laravel/envoy": "^1.4",
         "spatie/laravel-backup": "^5.0"
     },
     "autoload": {


### PR DESCRIPTION
Bumping envoy from `~1.3.4` to `^1.4` adds Laravel 5.6 support.

When installing `laravel/envoy` on a fresh Laravel 5.5 install it does require `^1.4`, which means this won't break the Laravel 5.5 support.